### PR TITLE
Using url value instead of real_url for display

### DIFF
--- a/stack/linklist.html
+++ b/stack/linklist.html
@@ -114,7 +114,7 @@
 	s0.9-1.9,1.9-1.9s1.9,0.9,1.9,1.9S6.6,13.9,5.5,13.9z M8.2,6.9H2.8V5.2c0-1.5,1.2-2.7,2.7-2.7s2.7,1.2,2.7,2.7
 	C8.2,5.2,8.2,6.9,8.2,6.9z"/></svg>
 		{/if}
-	<a href="{$value.real_url}" class="linklist-real-url"><span class="linklist-link">{$value.title_html}</span><span class="url-display">{$value.real_url}</span></a>
+	<a href="{$value.real_url}" class="linklist-real-url"><span class="linklist-link">{$value.title_html}</span><span class="url-display">{$value.url}</span></a>
 		</h2>
 					{if="$value.tags"}
 			<ul class="tags-header-linklist" aria-hidden="true">


### PR DESCRIPTION
While workin on a plugin that messes with the "real_url" (doing a redirect) I saw the use of "real_url" for display. As per the Shaarli documentation "url" is used for displayable links though hence the proposed change.