### PR TITLE
Set tags to wrap

### DIFF
--- a/stack/css/stack.css
+++ b/stack/css/stack.css
@@ -1519,7 +1519,7 @@ a:hover .svg-fill {
 .tags-header-linklist {
 	display: none;
 	flex-direction: row;
-	flex-wrap: no-wrap;
+	flex-wrap: wrap;
 	justify-content: flex-end;
 	list-style: none;
 	margin: 0;


### PR DESCRIPTION
This prevents a long list of tags from squashing the link title into a tiny space. Other consequences unknown.

Closes #10 